### PR TITLE
修复：文件的上传日期显示相差8小时

### DIFF
--- a/functions/admin.php
+++ b/functions/admin.php
@@ -63,7 +63,7 @@ $edit_files = true;
 
 // Default timezone for date() and time()
 // Doc - http://php.net/manual/en/timezones.php
-$default_timezone = 'UTC/GMT+08:00'; // UTC
+$default_timezone = 'Asia/Shanghai'; // UTC
 
 // Root path for file manager
 // use absolute path of directory i.e: '/var/www/folder' or $_SERVER['DOCUMENT_ROOT'].'/folder'


### PR DESCRIPTION
修复：文件的上传日期显示相差8小时
![image](https://user-images.githubusercontent.com/10511667/108233927-3641cf80-717f-11eb-9907-5e2caba1acdf.png)
